### PR TITLE
Add info on hour writing external workshops

### DIFF
--- a/planning_doc.Rmd
+++ b/planning_doc.Rmd
@@ -118,6 +118,7 @@ When not teaching, a training team member can do the following things:
 * Pre-workshop survey
 * Welcome procedure
 * Review Tasks
+* For external workshops: check the number of hours you have written so far and keep track of them in the table at the end of this document
 * Make sure the training team can contact each other in case a train is delayed or someone gets sick (confirm your way of communication via whatapp/teams/any way you prefer).
 
 ## Planning meeting (3 weeks before the workshop)
@@ -136,6 +137,7 @@ When not teaching, a training team member can do the following things:
 * Decide on setup sessions
 * Additional pre-workshop survey questions needed?
 * One person needed to help setting up and restoring the classroom
+* For external workshops: check the hours that are available and the exact code with the Training Coordinator, put them at the end of this document. Please keep track of the hours you have written in the table at the end of the document.
 * Assign Tasks in Planner, set deadlines.
 
 ### Table for keeping hours for external workshops


### PR DESCRIPTION
Added a point to the planning and calibration meeting agenda to go over the nr of hours available, the exact code and to keep track of them in the table.