### PR TITLE
Move description of roles to end of planning doc

### DIFF
--- a/planning_doc.Rmd
+++ b/planning_doc.Rmd
@@ -40,6 +40,54 @@ knitr::opts_chunk$set(echo = TRUE)
 * Participants Spreadsheet
 * Zoom Link
 
+Please see the end of this document for a description of the (lead) instructors and helpers roles.
+
+### Schedule & Teaching Division
+
+| Date | Lesson | Instructor | Designated Survivor | Zoom host | Note taker |
+|---|---|---|---|---|---|
+|   |   |   |   |   |   |
+
+
+## Calibration meeting (instructors + workshop coordinator, week before the workshop)
+
+### YYYY-MM-DD
+
+### Roll Call for this meeting
+
+#### Discussion Points & Notes
+
+* Pre-workshop survey
+* Welcome procedure
+* Review Tasks
+* For external workshops: check the number of hours you have written so far and keep track of them in the table at the end of this document
+* Make sure the training team can contact each other in case a train is delayed or someone gets sick (confirm your way of communication via whatapp/teams/any way you prefer).
+
+## Planning meeting (3 weeks before the workshop)
+
+### YYYY-MM-DD
+
+### Roll Call for this meeting
+
+#### Discussion Points & Notes
+
+* Confirm the Lead Instructor (chairs the meeting)
+* Assign note taker for this meeting (one of the helpers)
+* Select curriculum
+* Assign teaching
+* Assign helpers’ roles (designated survivor, Zoom Host, Note taker)
+* Decide on setup sessions
+* Additional pre-workshop survey questions needed?
+* One person needed to help setting up and restoring the classroom
+* For external workshops: check the hours that are available and the exact code with the Training Coordinator, put them at the end of this document. Please keep track of the hours you have written in the table at the end of the document.
+* Assign Tasks in Planner, set deadlines.
+
+### Table for keeping hours for external workshops
+
+| Instructor Name | Date | Prep & follow-up Hours | Hours on teaching itself | total hours written |
+|---|---|---|---|---|
+|   |   |   |   |   |
+
 ### Training team:  `r params$training_team`
 
 ### Training team general roles:
@@ -100,50 +148,3 @@ When not teaching, a training team member can do the following things:
 * Makes the log of all commands typed in by the Instructor 
 * Pastes exercises 
 * Keeps collaborative document clean 
-
-### Schedule & Teaching Division
-
-| Date | Lesson | Instructor | Designated Survivor | Zoom host | Note taker |
-|---|---|---|---|---|---|
-|   |   |   |   |   |   |
-
-
-## Calibration meeting (instructors + workshop coordinator, week before the workshop)
-
-### YYYY-MM-DD
-
-### Roll Call for this meeting
-
-#### Discussion Points & Notes
-
-* Pre-workshop survey
-* Welcome procedure
-* Review Tasks
-* For external workshops: check the number of hours you have written so far and keep track of them in the table at the end of this document
-* Make sure the training team can contact each other in case a train is delayed or someone gets sick (confirm your way of communication via whatapp/teams/any way you prefer).
-
-## Planning meeting (3 weeks before the workshop)
-
-### YYYY-MM-DD
-
-### Roll Call for this meeting
-
-#### Discussion Points & Notes
-
-* Confirm the Lead Instructor (chairs the meeting)
-* Assign note taker for this meeting (one of the helpers)
-* Select curriculum
-* Assign teaching
-* Assign helpers’ roles (designated survivor, Zoom Host, Note taker)
-* Decide on setup sessions
-* Additional pre-workshop survey questions needed?
-* One person needed to help setting up and restoring the classroom
-* For external workshops: check the hours that are available and the exact code with the Training Coordinator, put them at the end of this document. Please keep track of the hours you have written in the table at the end of the document.
-* Assign Tasks in Planner, set deadlines.
-
-### Table for keeping hours for external workshops
-
-| Instructor Name | Date | Prep & follow-up Hours | Hours on teaching itself | total hours written |
-|---|---|---|---|---|
-|   |   |   |   |   |
-


### PR DESCRIPTION
For clarity reasons I think it will be better to move the role description to the end of the planning doc.